### PR TITLE
feat: add vitest-support

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -17,6 +17,52 @@ jobs:
           npm ci
           npm run test:ci
         shell: bash
+      - uses: actions/github-script@v6
+        id: fix-coverage-report
+        with:
+          result-encoding: string
+          script: |
+            const fs = require('fs')
+            const reportFilename = 'report.json'
+            const coverageFinalFilename = 'coverage-final.json'
+            const cwd = process.cwd()
+
+            const reportJsonFilepath = `${cwd}/coverage/${reportFilename}`
+            const coverageFinalFilepath = `${cwd}/coverage/${coverageFinalFilename}`
+
+            let reportJsonFile
+            let coverageFinalJsonFile
+
+            if (fs.existsSync(reportJsonFilepath)) {
+              reportJsonFile = require(reportJsonFilepath)
+            }
+
+            if (fs.existsSync(coverageFinalFilepath)) {
+              coverageFinalJsonFile = require(coverageFinalFilepath)
+            }
+
+            console.log('Files exists?', { reportFilename: !!reportJsonFile, coverageFinalFilename: !!coverageFinalJsonFile })
+
+            if (reportJsonFile && coverageFinalJsonFile) {
+              if (!reportJsonFile.coverageMap) {
+                console.log(`Adding coverageMap property to ${reportFilename} based on ${coverageFinalFilename}`)
+
+                reportJsonFile.coverageMap = coverageFinalJsonFile
+
+                fs.writeFileSync(reportJsonFilepath, JSON.stringify(reportJsonFile), (err) => {
+                  if (err) {
+                    console.error(err)
+                    process.exit(1)
+                  }
+                })
+              } else {
+                console.log(`coverageMap already exists in ${reportFilename}, not doing anything...`)
+                process.exit(0)
+              }
+            } else {
+              console.log('Not doing anything...')
+              process.exit(0)
+            }
       - name: Download develop test report
         continue-on-error: true
         uses: dawidd6/action-download-artifact@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,6 +36,52 @@ jobs:
           npm run test:ci
         shell: bash
       - uses: actions/github-script@v6
+        id: fix-coverage-report
+        with:
+          result-encoding: string
+          script: |
+            const fs = require('fs')
+            const reportFilename = 'report.json'
+            const coverageFinalFilename = 'coverage-final.json'
+            const cwd = process.cwd()
+
+            const reportJsonFilepath = `${cwd}/coverage/${reportFilename}`
+            const coverageFinalFilepath = `${cwd}/coverage/${coverageFinalFilename}`
+
+            let reportJsonFile
+            let coverageFinalJsonFile
+
+            if (fs.existsSync(reportJsonFilepath)) {
+              reportJsonFile = require(reportJsonFilepath)
+            }
+
+            if (fs.existsSync(coverageFinalFilepath)) {
+              coverageFinalJsonFile = require(coverageFinalFilepath)
+            }
+
+            console.log('Files exists?', { reportFilename: !!reportJsonFile, coverageFinalFilename: !!coverageFinalJsonFile })
+
+            if (reportJsonFile && coverageFinalJsonFile) {
+              if (!reportJsonFile.coverageMap) {
+                console.log(`Adding coverageMap property to ${reportFilename} based on ${coverageFinalFilename}`)
+
+                reportJsonFile.coverageMap = coverageFinalJsonFile
+
+                fs.writeFileSync(reportJsonFilepath, JSON.stringify(reportJsonFile), (err) => {
+                  if (err) {
+                    console.error(err)
+                    process.exit(1)
+                  }
+                })
+              } else {
+                console.log(`coverageMap already exists in ${reportFilename}, not doing anything...`)
+                process.exit(0)
+              }
+            } else {
+              console.log('Not doing anything...')
+              process.exit(0)
+            }
+      - uses: actions/github-script@v6
         id: extract-coverage-pct
         with:
           result-encoding: string


### PR DESCRIPTION
Makes the `ArtiomTr/jest-coverage-report-action@v2` action work when using vitest.

Wish we could have it like an action but can't do that with reusable workflows... Thats why it's in-line!

Background: https://github.com/ArtiomTr/jest-coverage-report-action/issues/244#issuecomment-1260555231